### PR TITLE
feat: Add output format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Record an animated SVG into a video file without uploading anything.
 
-We use the modern browser JavaScript APIs to copy the SVG frames to a canvas and record the result into a WebM video file.
+We use the modern browser JavaScript APIs to copy the SVG frames to a canvas and record the result into a video file or zipped image sequence.
 It's a static website, without server side.
 There is no real SVG upload nor video download.
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
             <button>Record</button>
         </div>
     </form>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js" integrity="sha512-Qlv6VSKh1gDKGoJbnyA5RMXYcvnpIqhO++MhIM2fStMcGT9i2T//tSwYFlcyoRRDcDZ+TYHpH8azBBCyhpSeqw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src='main.js' defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,15 +11,20 @@
 <body>
     <h1>SVG Recorder</h1>
     <form>
-        <label for="svg"><input id="svg" name="svg" type="file" accept="image/svg+xml" required/><img alt="Uploaded image"/></label>
-        <label for="width">Width (px)<input id="width" name="width" type="number" min="1"/></label>
-        <label for="height">Height (px)<input id="height" name="height" type="number" min="1"/></label>
-        <input type="checkbox" id="link-dimensions" checked/><label for="link-dimensions">Link dimensions</label>
-        <label for="duration">Duration (ms)<input id="duration" name="duration" type="number" placeholder="5000" min="1"/></label>
-        <label for="framerate">Framerate<input id="framerate" name="framerate" type="number" placeholder="30" min="1"/></label>
-        <label for="background">Background color<input id="background" name="background" type="color" value="#FFFFFF" required/></label>
-        <label for="format">Output format:<select id="format" name="format" required></select></label>
-        <button>Record</button>
+        <div id="svgPage" class="page">
+            <label for="svg">Choose an SVG file</label>
+            <input id="svg" name="svg" type="file" accept="image/svg+xml" required/>
+        </div>
+        <div id="optionsPage" class="page">
+            <label for="width">Width (px)<input id="width" name="width" type="number" min="1"/></label>
+            <label for="height">Height (px)<input id="height" name="height" type="number" min="1"/></label>
+            <input type="checkbox" id="link-dimensions" checked/><label for="link-dimensions">Link dimensions</label>
+            <label for="duration">Duration (ms)<input id="duration" name="duration" type="number" placeholder="5000" min="1"/></label>
+            <label for="framerate">Framerate<input id="framerate" name="framerate" type="number" placeholder="30" min="1"/></label>
+            <label for="background">Background color<input id="background" name="background" type="color" value="#FFFFFF" required/></label>
+            <label for="format">Output format:<select id="format" name="format" required></select></label>
+            <button>Record</button>
+        </div>
     </form>
     <script src='main.js' defer></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <label for="duration">Duration (ms)<input id="duration" name="duration" type="number" placeholder="5000" min="1"/></label>
         <label for="framerate">Framerate<input id="framerate" name="framerate" type="number" placeholder="30" min="1"/></label>
         <label for="background">Background color<input id="background" name="background" type="color" value="#FFFFFF" required/></label>
+        <label for="format">Output format:<select id="format" name="format" required></select></label>
         <button>Record</button>
     </form>
     <script src='main.js' defer></script>

--- a/main.css
+++ b/main.css
@@ -1,11 +1,11 @@
 *, *::before, *::after {
     margin: 0;
     padding: 0;
-    box-sizing: border-box;
+    /*box-sizing: border-box;*/
     color: inherit;
     text-decoration: none;
     list-style: none;
-    transition-duration: 300ms;
+    transition-duration: 3000ms;
     transition-property: none;
 }
 
@@ -33,16 +33,28 @@ body {
     text-align: center;
     background-color: var(--background-color);
     color: var(--text-color);
+    overflow: auto;
 }
 
 h1 {
+    position:fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
     padding: 8pt;
     box-shadow: 0px 4px 16px rgba(var(--text-color-rgb), 0.25), 0px 1px 8px rgba(var(--background-color-rgb), 0.15);
     font-size: 200%;
+    z-index: 1;
+    background-color: var(--background-color);
 }
 
 form {
-    position: relative;
+    --svg-box-height: 200px;
+    margin: calc(50vh - var(--svg-box-height) / 2) auto 0 auto;
+    overflow: auto;
+    display: inline-block;
+    transition-property: margin;
+    /*position: relative;
     width: 90%;
     max-width: 300pt;
     max-height: calc(100% - var(--title-size));
@@ -51,15 +63,45 @@ form {
     padding: calc(var(--seprataion-size) * var(--base)) 0;
     overflow: hidden;
     transform: translateY(-50%);
-    transition-property: max-height, padding, top, transform, margin-bottom;
+    transition-property: max-height, padding, top, transform, margin-bottom;*/
+}
+
+form:has(label[for=svg].choosen) {
+    margin-top: var(--title-size);
+}
+
+form > div {
+    margin: calc(var(--seprataion-size) * var(--base)) 0;
+}
+
+#svgPage {
+    height: var(--svg-box-height);
+    transition-property: height;
+    border: 4pt dashed;
+    border-radius: calc(var(--seprataion-size) * var(--base));
+    width: 300pt;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#svgPage:has(label[for=svg].choosen) {
+    --svg-box-height: 100px;
+}
+
+#optionsPage {
+    display: none;
+    height: 0;
+    overflow: clip;
+    transition-property: height;
+}
+
+#optionsPage.visible {
+    display: block;
 }
 
 .recording > form {
-    max-height: 0;
-    padding: 0;
-    top: 0;
-    transform: translate(0);
-    margin-bottom: calc(var(--seprataion-size) * var(--base));
+    display: none;
 }
 
 label {
@@ -86,57 +128,42 @@ input,select {
 }
 
 label[for=svg] {
-    --svg-label-height: 200px;
-    position: relative;
+    margin: 0;
+    max-height: 100%;
+    max-width: 100%;
+    /*position: relative;
     margin: calc((100vh - var(--title-size) - var(--seprataion-size) * var(--base) - var(--svg-label-height)) / 2) 0;
-    height: var(--svg-label-height);
-    border: 4pt dashed;
-    border-radius: calc(var(--seprataion-size) * var(--base));
-    transition-property: margin, height;
+    transition-property: margin, height;*/
 }
 
-label[for=svg].choosen {
-    --svg-label-height: 100px;
-    margin-top: 0px;
-    margin-bottom: calc(var(--seprataion-size) * var(--base));
-}
-
-label[for=svg]::before {
-    content: "Choose SVG file";
-}
-
-label[for=svg] > input {
-    position: absolute;
+#svg {
+    position: fixed;
     width: 100%;
     height: 100%;
     top: 0;
     left: 0;
     opacity: 0;
     margin: 0;
-    z-index: 1;
+    z-index: 2;
+}
+
+#svgPage:has(label[for=svg].choosen) #svg {
+    display: none;
 }
 
 label[for=svg] > img {
     max-width: 100%;
-    max-height: 100%;
-    display: none;
-}
-
-label[for=svg] > img[src] {
-    display: initial;
-}
-
-label[for=svg]::before,
-label[for=svg] > img {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    max-height: var(--svg-box-height);
+    transition-property: max-height;
 }
 
 body > img {
     position: absolute;
     right: 100%;
+}
+
+.recording canvas {
+    margin-top: calc(var(--title-size) + var(--seprataion-size) * var(--base));
 }
 
 /* Buttons */

--- a/main.css
+++ b/main.css
@@ -72,7 +72,7 @@ label:focus-within {
     opacity: 1;
 }
 
-input {
+input,select {
     display: block;
     width: 100%;
     font-size: inherit;
@@ -159,7 +159,7 @@ button:hover {
 
 
 @media (prefers-color-scheme: dark) {
-    :root {    
+    :root {
         --background-color-rgb: 30, 35, 44;
         --text-color-rgb: 255, 255, 255;
     }

--- a/main.css
+++ b/main.css
@@ -1,7 +1,7 @@
 *, *::before, *::after {
     margin: 0;
     padding: 0;
-    /*box-sizing: border-box;*/
+    box-sizing: border-box;
     color: inherit;
     text-decoration: none;
     list-style: none;
@@ -54,16 +54,6 @@ form {
     overflow: auto;
     display: inline-block;
     transition-property: margin;
-    /*position: relative;
-    width: 90%;
-    max-width: 300pt;
-    max-height: calc(100% - var(--title-size));
-    top: calc((100% - var(--title-size)) / 2);
-    margin: auto;
-    padding: calc(var(--seprataion-size) * var(--base)) 0;
-    overflow: hidden;
-    transform: translateY(-50%);
-    transition-property: max-height, padding, top, transform, margin-bottom;*/
 }
 
 form:has(label[for=svg].choosen) {
@@ -131,9 +121,6 @@ label[for=svg] {
     margin: 0;
     max-height: 100%;
     max-width: 100%;
-    /*position: relative;
-    margin: calc((100vh - var(--title-size) - var(--seprataion-size) * var(--base) - var(--svg-label-height)) / 2) 0;
-    transition-property: margin, height;*/
 }
 
 #svg {

--- a/main.css
+++ b/main.css
@@ -5,7 +5,7 @@
     color: inherit;
     text-decoration: none;
     list-style: none;
-    transition-duration: 3000ms;
+    transition-duration: 500ms;
     transition-property: none;
 }
 

--- a/main.js
+++ b/main.js
@@ -2,9 +2,9 @@
 
 const body = document.body,
     form = document.querySelector('form'),
-    svgLabel = form.svg.parentNode,
-    previewer = svgLabel.querySelector('img'),
-    format = form.format;
+    svgLabel = form.querySelector('label[for="svg"]'),
+    format = form.format,
+    optionsPage = document.getElementById('optionsPage');
 
 let initTime;
 
@@ -22,8 +22,17 @@ function getSupportedFormatString(container, codecs) {
 
 form.svg.onchange = function(event) {
     const [file] = form.svg.files;
+    let previewer = document.createElement('img');
+    previewer.onload = function() {
+        form.width.placeholder = previewer.naturalWidth;
+        form.height.placeholder = previewer.naturalHeight;
+    }
     previewer.src = URL.createObjectURL(file);
+    svgLabel.innerHTML = '';
+    svgLabel.appendChild(previewer);
     svgLabel.className = 'choosen';
+    optionsPage.className = 'visible';
+    optionsPage.style.height = optionsPage.scrollHeight + 'px';
 
     // Populate formats dropdown
     const allContainers = {'Matroska': 'x-matroska', 'WebM': 'webm', 'Ogg': 'ogg', 'MPEG-4': 'mp4', 'MPEG-2': 'mpeg', 'QuickTime': 'quicktime'};
@@ -50,11 +59,6 @@ form.svg.onchange = function(event) {
     // TODO: read the canvas sources
     // TODO: get the canvas width and height to set the attributes in the in the SVG node (see https://stackoverflow.com/a/28692538)
     // TODO: get the animation duration
-}
-
-previewer.onload = function() {
-    form.width.placeholder = previewer.naturalWidth;
-    form.height.placeholder = previewer.naturalHeight;
 }
 
 form.onsubmit = function (event) {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

This PR adds support for other output formats. Depending on the browser, multiple container formats and video codecs are supported by MediaRecorder and will be automatically added as options. Additionally, a image sequence export options (PNG, JPEG, WebP) have been added (again if supported).

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

For the new video formats, they are passed as MIME types to `MediaRecorder`, and supported formats are determined through `MediaRecorder.isTypeSupported`. For the image sequence formats, the canvas is rendered to blobs using `toBlob`, and a zip file is generated using JSZip.

This PR adds two external library dependencies, JSZip and FileSaver.js, which are included with CdnJS to maintain full functionality as a static website. FileSaver.js provides better cross-browser support for initiating the download of the blobs, and supports larger file sizes than data urls in some cases.

The stylesheet and html has been changed somewhat to support scrolling if the options are taller than the browser window. The animated transitions have been preserved. The code is not exactly pretty but it works.

There is also a change to when images are rendered to the canvas. Instead of calling `render()` on every iteration of `renderLoop()`, it will instead only be called on the first iteration of each frame at the user-specified frame rate. This was necessary to preserve the timing for image exporting, and has the added benefit of not rendering frame that will not be used.

## How to test my changes
You can test my changes at this URL: https://scribblemaniac.github.io/svg-recorder/

It has been tested and is working in Firefox.

## Checklist
- [x] I didn't over-scope my PR (well maybe just a little :blush:)
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [x] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


